### PR TITLE
Disable ssh password login for all created users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ default_update_password: on_create
 default_shell: /bin/bash
 # default_generate_ssh_key_comment: "ansible-generated on {{ ansible_hostname }}"
 default_generate_ssh_key_comment: "ansible-generated for {{ item.username }}@{{ ansible_hostname }}"
+default_disable_ssh_password_authentication: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -146,6 +146,14 @@
   loop_control:
     label: "username: {{ item.username }}, generate_ssh_key: {{ 'True' if item.generate_ssh_key is defined else 'False' }}, ssh_key_bits: {{ item.ssh_key_bits if item.ssh_key_bits is defined else '' }}, ssh_key_passphrase: {{ 'True' if item.ssh_key_passphrase is defined else 'False' }}, generate_ssh_key_comment: {{ item.generate_ssh_key_comment if item.generate_ssh_key_comment is defined else default_generate_ssh_key_comment }}"
 
+- name: SSH Keys | Disable SSH passwordlogin for added users
+  ansible.builtin.blockinfile:
+    path: /etc/ssh/sshd_config
+    block: |
+      Match User {{ users | map(attribute='username') | join(',') }}
+      PasswordAuthentication no
+    when: default_disable_ssh_password_authentication
+
 - name: Sudo | add to sudoers file and validate
   lineinfile:
     dest: /etc/sudoers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -147,12 +147,12 @@
     label: "username: {{ item.username }}, generate_ssh_key: {{ 'True' if item.generate_ssh_key is defined else 'False' }}, ssh_key_bits: {{ item.ssh_key_bits if item.ssh_key_bits is defined else '' }}, ssh_key_passphrase: {{ 'True' if item.ssh_key_passphrase is defined else 'False' }}, generate_ssh_key_comment: {{ item.generate_ssh_key_comment if item.generate_ssh_key_comment is defined else default_generate_ssh_key_comment }}"
 
 - name: SSH Keys | Disable SSH passwordlogin for added users
-  ansible.builtin.blockinfile:
+  blockinfile:
     path: /etc/ssh/sshd_config
     block: |
       Match User {{ users | map(attribute='username') | join(',') }}
       PasswordAuthentication no
-    when: default_disable_ssh_password_authentication
+  when: default_disable_ssh_password_authentication
 
 - name: Sudo | add to sudoers file and validate
   lineinfile:


### PR DESCRIPTION
Through changing sshd_config the parameter 'PasswordAuthentication no' can be set for the provided list of users.
This is only recommended when a ssh-key is provided for every user.