### PR TITLE
add inventory_hostname to group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 Role to manage users on linux.  
 Manage users in the user list config file (list is in the file vars/secret).  
 Add users (with specific uid), change passwords, lock/unlock user accounts, manage sudo access (per user), add ssh key(s) for sshkey based authentication, set user's primary group and gid, add user (append) to group(s) and group will be created if doesn't exist.  
-This is done on a per "group" basis (Ansible group variables), as set in the config file. The group comes from the Ansible group as set for a server in the inventory file. `all` is also supported to apply to every host in an inventory file.  
+This is done on a per "group" basis (Ansible group variables), as set in the config file. The group comes from the Ansible group as set for a server in the inventory file.  
+  `all` is also supported to apply to every host in an inventory file.  
+  Special variable `inventory_hostname` is also supported to apply to just one server in an inventory file.  
 
 More detailed example can be found in the blog post: [User Management with Ansible](https://ryandaniels.ca/blog/ansible-user-management/)  
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,7 +19,8 @@
         use_sudo: false
         user_state: present
         servers:
-          - webserver
+          - instance
+          # - webserver
           - database
           - monitoring
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: set_fact - add all to group_names
   set_fact:
-    create_users_group_names: "{{ group_names|default([]) + ['all'] }}"
+    create_users_group_names: "{{ group_names|default([]) + ['all'] + [inventory_hostname] }}"
 
 - name: debug variable create_users_group_names
   debug: var=create_users_group_names


### PR DESCRIPTION
Allows single hostname instead of creating a group with 1 host.
Fixes #20 